### PR TITLE
mmap(2) returns MAP_FAILED when it fails.

### DIFF
--- a/debug_malloc.c
+++ b/debug_malloc.c
@@ -15,7 +15,7 @@ void* malloc(size_t rawSize) {
 
     void* allMemory = mmap(NULL, numTotalPages * page, PROT_READ | PROT_WRITE,
             MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
-    if (!allMemory) {
+    if (allMemory == MAP_FAILED) {
         return NULL;
     }
 


### PR DESCRIPTION
NULL can be a valid address.