### PR TITLE
Invalid mmap(2) call with MAP_ANONYMOUS and fd 0

### DIFF
--- a/debug_malloc.c
+++ b/debug_malloc.c
@@ -14,7 +14,7 @@ void* malloc(size_t rawSize) {
     int numTotalPages = numGivenPages + 1;
 
     void* allMemory = mmap(NULL, numTotalPages * page, PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (allMemory == MAP_FAILED) {
         return NULL;
     }


### PR DESCRIPTION
The code contains a non-portable use of **mmap(2)**. It requests `MAP_ANONYMOUS`, but the file descriptor is not `-1`. POSIX specified that in case of `MAP_ANONYMOUS`, the file descriptor should be `-1`, otherwise the effect is unspecified.[^1] Apparently Linux simply ignores the file descriptor in this case, but other implementations such as FreeBSD kernel, may reject it with an `EINVAL`.[^2]

The file descriptor should be set to `-1` for anonymous pages.

[^1]: [mmap](https://pubs.opengroup.org/onlinepubs/9799919799/functions/mmap.html) - The Open Group Base Specifications Issue 8
[^2]: [mmap(2)](https://man.freebsd.org/cgi/man.cgi?query=mmap&sektion=2&manpath=FreeBSD+12.2-RELEASE&format=html#ERRORS) - FreeBSD Manual Pages
